### PR TITLE
Fix AbstractMethodError when proguard enabled

### DIFF
--- a/examples/android-proguard-example/proguard.cfg
+++ b/examples/android-proguard-example/proguard.cfg
@@ -13,8 +13,9 @@
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.google.gson.examples.android.model.** { <fields>; }
 
-# Prevent proguard from stripping interface information from TypeAdapterFactory,
+# Prevent proguard from stripping interface information from TypeAdapter,TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * extends com.google.gson.TypeAdapter
 -keep class * implements com.google.gson.TypeAdapterFactory
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer


### PR DESCRIPTION
Fix AbstractMethodError when proguard enabled and using TypeAdapter, because of type info erased in TypeAdapter.nullSave() and implemention method removed in TypeAdapter's subclass.